### PR TITLE
Move docker base to debian vs alpine

### DIFF
--- a/service_base/Dockerfile
+++ b/service_base/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine
+FROM node:lts
 
 RUN apk add --update openssl && \
     rm -rf /var/cache/apk/*


### PR DESCRIPTION
Moves the base to debian vs alpine.

Base images within the RO ecosystem use debian as their base not alpine.  If a community need comes up for sharing the container via alpine we can expose multiple builds later.